### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /bin
 /*.factorypath
 /*.versionsBackup
+**.jks
+**.pem
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Launch Application",
+            "request": "launch",
+            "mainClass": "us.dot.its.jpo.sec.Application",
+            "projectName": "jpo-security-svcs"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
             "name": "Launch Application",
             "request": "launch",
             "mainClass": "us.dot.its.jpo.sec.Application",
-            "projectName": "jpo-security-svcs"
+            "projectName": "jpo-security-svcs",
+            "envFile": "${workspaceFolder}/.env"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM maven:3.5.4-jdk-8-alpine as builder
-MAINTAINER 583114@bah.com
 
 WORKDIR /home
 COPY ./pom.xml .
@@ -11,5 +10,8 @@ FROM openjdk:8u171-jre-alpine
 
 COPY --from=builder /home/src/main/resources/logback.xml /home
 COPY --from=builder /home/target/jpo-security-svcs.jar /home
+COPY --from=builder /home/src/main/resources/creds/cert.jks /home
+ADD ./src/main/resources/creds/caCerts /usr/local/share/ca-certificates
+RUN update-ca-certificates
 
 CMD ["java", "-Dlogback.configurationFile=/home/logback.xml", "-jar", "/home/jpo-security-svcs.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,5 @@ FROM openjdk:8u171-jre-alpine
 
 COPY --from=builder /home/src/main/resources/logback.xml /home
 COPY --from=builder /home/target/jpo-security-svcs.jar /home
-COPY --from=builder /home/src/main/resources/creds/cert.jks /home
-ADD ./src/main/resources/creds/caCerts /usr/local/share/ca-certificates
-RUN update-ca-certificates
 
 CMD ["java", "-Dlogback.configurationFile=/home/logback.xml", "-jar", "/home/jpo-security-svcs.jar"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 
 # jpo-security-svcs
-This module exposes a RESTful API for performing cryptographic functions. The cryptographic functions may be carried out against an on-prem instance, or against a remote instance. Note that for the remote signing use case, MTLS will be used to secure the communications. This requires some additional work on the part of configuration. The following paths identify the functions:
+This module exposes a RESTful API for performing cryptographic functions. The following paths identify the functions:
 |Verb|path|Content Type|Functionality|Request Body Format|Response Body Format|
 |--|--|--|--|--|--|
 |POST|/sign|application/json|signs data provided in the body of the request|{"message":"Base64 encoded unsigned data"}|{"result": "Base64 Encoded Signed Data"}
 
+
+Note that the cryptographic functions may be carried out against an on-prem instance, or against a remote instance. A local instance is a simplified case and does not require mutual TLS authentication. For the remote signing use case, MTLS will be used to secure the communications. This requires some additional work on the part of configuration, and uses private and public keys to secure the communications between this instance and the remote signing instance.
 ## Mutual TLS Authentication
 For enhanced security, MTLS is used to communicate with a remote signing system. This requires properly configured certificates from the remote system to property perform - work with your remote signing authority to obtain necessary certificates. 
 
 ### Certificate Conversion
 Certificates can be in several different formats, including the widely used PEM format. Because this is a Java application, the signing certificates must be in the Java Keystore format to be used. The following commands using [OpenSSL](https://www.openssl.org/) and the Java keytool will convert a PEM file to a Java Keystore file.
 
-First we convert the PEM file to a PKCS12 file:
+1. Convert the PEM file to a PKCS12 file:
 ```
 openssl pkcs12 -export -in <cert.pem> -inkey <key.pem> -out <certificate.p12> -name <alias>
 ```
-Then we convert the PKCS12 file to a Java Keystore file:
+2. Convert the PKCS12 file to a Java Keystore file:
 ```
 keytool -importkeystore -srckeystore <certificate.p12> -srcstoretype pkcs12 -destkeystore <cert.jks>
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 
 # jpo-security-svcs
-This module expopsed a RESTful API for performing cryptographic functions. The following paths identify the functions:
+This module exposes a RESTful API for performing cryptographic functions. The cryptographic functions may be carried out against an on-prem instance, or against a remote instance. Note that for the remote signing use case, MTLS will be used to secure the communications. This requires some additional work on the part of configuration. The following paths identify the functions:
 |Verb|path|Content Type|Functionality|Request Body Format|Response Body Format|
 |--|--|--|--|--|--|
 |POST|/sign|application/json|signs data provided in the body of the request|{"message":"Base64 encoded unsigned data"}|{"result": "Base64 Encoded Signed Data"}
 
+## Mutual TLS Authentication
+For enhanced security, MTLS is used to communicate with a remote signing system. This requires properly configured certificates from the remote system to property perform - work with your remote signing authority to obtain necessary certificates. 
+
+### Certificate Conversion
+Certificates can be in several different formats, including the widely used PEM format. Because this is a Java application, the signing certificates must be in the Java Keystore format to be used. The following commands using [OpenSSL](https://www.openssl.org/) and the Java keytool will convert a PEM file to a Java Keystore file.
+
+First we convert the PEM file to a PKCS12 file:
+```
+openssl pkcs12 -export -in <cert.pem> -inkey <key.pem> -out <certificate.p12> -name <alias>
+```
+Then we convert the PKCS12 file to a Java Keystore file:
+```
+keytool -importkeystore -srckeystore <certificate.p12> -srcstoretype pkcs12 -destkeystore <cert.jks>
+```
+
+### Certificate Authority Issues
+If your remote signing authority is using their own certificates as a CA, you may need to import those certificates into your Java truststore to allow the handshake to go through. Note that when running the dockerized application, these CA certificates are to be one certificate per file (chain certificates are not supported).
+
 ## Install
 
 `mvn clean install`
+
+
+## Debug
+If running in VS Code, a launch.json has been included to allow for ease of debugging. A .env file can be created using the sample.env file as a starting point. Once this settings file is in place, simply click the green arrow in the debug tab to run the application. At this point all breakpoints will function as expected.
 
 ## Run
 
@@ -22,6 +44,20 @@ This module expopsed a RESTful API for performing cryptographic functions. The f
 (Take note of image reported by docker build)
 
 `docker run -p 8090:8090 <image>`
+
+### Docker Compose
+A docker-compose.yml file has been included as an example for running the application under Docker Compose. Additionally a sample.env has been included to show which values are expected. 
+
+The docker-compose.yml file is configured for using certificates, and mounts a volume to the container pointing to the local `./src/main/resources/creds` directory. This directory (or another you chose to point to) should contain your own JKS used to sign messages for MTLS. It should also contain a subdirectory, "caCerts", containing any CA certificates (one per file) from the remote system that need to be installed in the Java truststore on boot. 
+
+To use, copy the sample.env file to a new '.env' file and replace with your settings. Then, simply run the following command:
+```
+docker-compose up --build -d
+```
+This will spin up a new container and run it listening on port 8090. To stop the container, run the following command:
+```
+docker-compose down
+```
 
 ## Test
 
@@ -43,10 +79,14 @@ Expected output:
 
 ## Configuration
 
-In `./src/main/resources/application.properties` you'll find the following properties which can be defined wither on the command line or by environment variable. To define the property on the command line, insert `--` to the front of the Property name, for example, `--server.port=8091`:
+In `./src/main/resources/application.properties` you'll find the following properties which can be defined whether on the command line or by environment variable. To define the property on the command line, insert `--` to the front of the Property name, for example, `--server.port=8091`:
 
 | Property | Meaning | Default Value | Environment Variable Substitute |
 | -----------|------------|-----------------|-----------|
 | server.port | The port number to which this service will be listening.| 8090 |SERVER_PORT|
+| sec.useHsm | Whether to use an HSM or not. | false | SEC_USE_HSM |
 | sec.cryptoServiceBaseUri | Cryptographic service endpoint URI excluding path. For example, `http://<ip>:<port>` OR `http://server.dns.name` including the port number, if any. | - |SEC_CRYPTO_SERVICE_BASE_URI|
 | sec.cryptoServiceEndpointSignPath | The REST endpoint path of the external service. | /tmc/signtim |SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH|
+| sec.useCertficates | Whether to use certificates or not. | true | SEC_USE_CERTIFICATES |
+| sec.keyStorePath | The path to the keystore file. | /home/cert.jks | SEC_KEY_STORE_PATH |
+| sec.keyStorePassword | The password for the keystore file. | password | SEC_KEY_STORE_PASSWORD |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+# DOCKER_SHARED_VOLUME_WINDOWS should be defined for Windows host machine as C: and not defined for Linux hosts
+
+version: '3'
+services:
+  sec:
+    build: .
+    image: jpoode_sec:latest
+    ports:
+     - "8090:8090"
+    environment:
+      SEC_CRYPTO_SERVICE_BASE_URI: ${SEC_CRYPTO_SERVICE_BASE_URI}
+      SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH: ${SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH}
+      SEC_USE_CERTFICATES: ${SEC_USE_CERTFICATES}
+      SEC_KEY_STORE_PATH: ${SEC_KEY_STORE_PATH}
+      SEC_KEY_STORE_PASSWORD: ${SEC_KEY_STORE_PASSWORD}
+    volumes: 
+      - ./src/main/resources/creds:/home/creds
+    command: sh -c "cp -a /home/creds/caCerts/. /usr/local/share/ca-certificates/ && update-ca-certificates && java -Dlogback.configurationFile=/home/logback.xml -jar /home/jpo-security-svcs.jar"
+    logging:
+      options:
+        max-size: "10m"  
+        max-file: "5"

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,16 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,8 @@
+SEC_CRYPTO_SERVICE_BASE_URI=
+#The REST endpoint path of the xternal service if `sec.useHsm=false`
+SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH=/tmc/signtim
+
+SEC_USE_CERTFICATES=true
+#The following properties are valid only if sec.useCertficates=true
+SEC_KEY_STORE_PATH=/home/cert.jks
+SEC_KEY_STORE_PASSWORD=password

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 SEC_CRYPTO_SERVICE_BASE_URI=
-#The REST endpoint path of the xternal service if `sec.useHsm=false`
+#The REST endpoint path of the external service if `sec.useHsm=false`
 SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH=/tmc/signtim
 
 SEC_USE_CERTFICATES=true

--- a/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -15,6 +15,8 @@
  ******************************************************************************/
 package us.dot.its.jpo.sec.controllers;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -210,7 +212,7 @@ public class SignatureController implements EnvironmentAware {
    }
 
    private KeyStore readStore() throws Exception {
-      try (InputStream keyStoreStream = this.getClass().getResourceAsStream(keyStorePath)) {
+      try (InputStream keyStoreStream = new FileInputStream(new File(keyStorePath))) {
          KeyStore keyStore = KeyStore.getInstance("JKS");
          keyStore.load(keyStoreStream, keyStorePassword.toCharArray());
          return keyStore;

--- a/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
+++ b/src/main/java/us/dot/its/jpo/sec/controllers/SignatureController.java
@@ -15,12 +15,22 @@
  ******************************************************************************/
 package us.dot.its.jpo.sec.controllers;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyStore;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,17 +64,18 @@ public class SignatureController implements EnvironmentAware {
    @Autowired
    private Environment env;
 
-//   private static final String MOCK_MESSAGE = "03810040038081a3d34d45e80ef4db807dd35102f42db7e81d34d34d34d34d34d05efbe43f41d37d35100ef7138e760f5e77f7bd7a0bdf44f43e79e75d34d34dc5d00e7d074f34d35d37d3b17c000f7defd1780f7041dc0d00f76eba0b4d34d34d3ce781370760b8ef6f75176d44f39104134e7bf7cd34dbce36d02e45dbad7bd79e3617c14407c13cd7b0bcdc30ba17c044e35d84dfc0b9176d03ef50b8db5f34d34db4d770c30fbeba0b60018300019924e7b3b2720001992842024272810101000301801631afb5fc255d0f508208f49317071422d1925e6f5b00031acb5dbc8400a983010180034801010001838182792f4e20404c92bf0707999b338ef65e6d6f110bfbf1b67a360ed8a8e412bfa88083a83da9c99739b68f2eff338bbb4b9af2982fe50d843f0f896b9cf291e5d39d1417be0d856eaaea639de2f6ff2d42928e0e2374cbe1ac5dc0d065b0a36ecdfac6";
-
    public String cryptoServiceBaseUri;
    private String cryptoServiceEndpointSignPath;
-//   public boolean mockResponse;
    public boolean useHsm;
 
-   public static class Message{
+   private boolean useCertficates;
+   private String keyStorePath;
+   private String keyStorePassword;
+
+   public static class Message {
       @JsonProperty("message")
       public String msg;
-      
+
       @JsonProperty("sigValidityOverride")
       public int sigValidityOverride = 0;
    }
@@ -73,58 +84,54 @@ public class SignatureController implements EnvironmentAware {
 
    @RequestMapping(value = "/sign", method = RequestMethod.POST, produces = "application/json")
    @ResponseBody
-   public ResponseEntity<Map<String,String>> sign(@RequestBody Message message) throws URISyntaxException {
+   public ResponseEntity<Map<String, String>> sign(@RequestBody Message message) throws URISyntaxException {
 
       logger.info("Received message: {}", message.msg);
       logger.info("Received sigValidityOverride: {}", message.sigValidityOverride);
 
-      ResponseEntity<Map<String,String>> response;
-      
-//      logger.info("mockResponse == {}", mockResponse);
-//
-//      if (mockResponse) {
-//         logger.info("Returning mock response");
-//         response = ResponseEntity.status(HttpStatus.OK).body(
-//            Collections.singletonMap("result", MOCK_MESSAGE));
-//      } else if (useHsm) {
+      ResponseEntity<Map<String, String>> response;
+
       if (useHsm) {
          logger.info("Signing using HSM");
          response = signWithHsm(message);
       } else {
-         logger.debug("Before trimming: cryptoServiceBaseUri={}, cryptoServiceEndpointSignPath={}", cryptoServiceBaseUri, cryptoServiceEndpointSignPath);
-         //Remove all slashes from the end of the URI, if any
+         logger.debug("Before trimming: cryptoServiceBaseUri={}, cryptoServiceEndpointSignPath={}",
+               cryptoServiceBaseUri, cryptoServiceEndpointSignPath);
+         // Remove all slashes from the end of the URI, if any
          while (cryptoServiceBaseUri != null && cryptoServiceBaseUri.endsWith("/")) {
             cryptoServiceBaseUri = cryptoServiceBaseUri.substring(0, cryptoServiceBaseUri.lastIndexOf('/'));
          }
 
-         //Remove all slashes from the beginning of the path string, if any
+         // Remove all slashes from the beginning of the path string, if any
          while (cryptoServiceEndpointSignPath != null && cryptoServiceEndpointSignPath.startsWith("/")) {
             cryptoServiceEndpointSignPath = cryptoServiceEndpointSignPath.substring(1);
          }
 
-         logger.debug("After Trimming: cryptoServiceBaseUri={}, cryptoServiceEndpointSignPath={}", cryptoServiceBaseUri, cryptoServiceEndpointSignPath);
-       
+         logger.debug("After Trimming: cryptoServiceBaseUri={}, cryptoServiceEndpointSignPath={}", cryptoServiceBaseUri,
+               cryptoServiceEndpointSignPath);
+
          String resultString = message.msg;
          if (!StringUtils.isEmpty(cryptoServiceBaseUri) && !StringUtils.isEmpty(cryptoServiceEndpointSignPath)) {
             logger.info("Sending signature request to external service");
-            ResponseEntity<String> result = forwardMessageToExternalService(message);
-   
-            JSONObject json = new JSONObject(result.getBody());
-            
-            resultString = json.getString("message-signed");
-            Map<String, String> mapResult = new HashMap<>();
-            try 
-            {
-            
-               mapResult.put("message-expiry", String.valueOf(json.getLong("message-expiry")));
-               
+            JSONObject json = forwardMessageToExternalService(message);
+
+            if (json != null) {
+               resultString = json.getString("message-signed");
+               Map<String, String> mapResult = new HashMap<>();
+               try {
+
+                  mapResult.put("message-expiry", String.valueOf(json.getLong("message-expiry")));
+
+               } catch (Exception e) {
+                  mapResult.put("message-expiry", "null");
+               }
+               mapResult.put("message-signed", resultString);
+               response = ResponseEntity.status(HttpStatus.OK)
+                     .body(Collections.singletonMap("result", new JSONObject(mapResult).toString()));
+            } else {
+               response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                     .body(Collections.singletonMap("error", "Error communicating with external service"));
             }
-            catch(Exception e)
-            {
-               mapResult.put("message-expiry", "null");
-            }
-				mapResult.put("message-signed", resultString);
-            response = ResponseEntity.status(HttpStatus.OK).body(Collections.singletonMap("result", new JSONObject(mapResult).toString()));
          } else {
             String msg = "Properties sec.cryptoServiceBaseUri=" + cryptoServiceBaseUri
                   + ", sec.cryptoServiceEndpointSignPath=" + cryptoServiceEndpointSignPath
@@ -135,49 +142,86 @@ public class SignatureController implements EnvironmentAware {
             result.put("warn", msg);
             response = ResponseEntity.status(HttpStatus.NOT_FOUND).body(result);
          }
-         
-         
+
       }
 
       return response;
 
    }
 
-   private ResponseEntity<String> forwardMessageToExternalService(Message message) throws URISyntaxException {
+   private JSONObject forwardMessageToExternalService(Message message) throws URISyntaxException {
 
       HttpHeaders headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
-      Map<String,String> map;
-      
-      if(message.sigValidityOverride > 0) 
-      {
-    	  map = new HashMap<>();
-    	  map.put("message",message.msg);
-    	  map.put("sigValidityOverride", Integer.toString(message.sigValidityOverride));
+      Map<String, String> map;
+
+      if (message.sigValidityOverride > 0) {
+         map = new HashMap<>();
+         map.put("message", message.msg);
+         map.put("sigValidityOverride", Integer.toString(message.sigValidityOverride));
+      } else {
+         map = Collections.singletonMap("message", message.msg);
       }
-      else 
-      {
-    	 map = Collections.singletonMap("message", message.msg); 
-      }     
-      HttpEntity<Map<String, String>> entity = new HttpEntity<>(map, headers); 
+      HttpEntity<Map<String, String>> entity = new HttpEntity<>(map, headers);
       RestTemplate template = new RestTemplate();
 
       logger.debug("Received request: {}", entity);
 
       URI uri = new URI(cryptoServiceBaseUri + "/" + cryptoServiceEndpointSignPath);
-      
+
       logger.debug("Sending request to: {}", uri);
 
-      ResponseEntity<String> respEntity = template.postForEntity(uri, entity, String.class);
+      if (useCertficates) {
+         try {
+            SSLContext sslContext = SSLContexts.custom()
+                  .loadKeyMaterial(readStore(), keyStorePassword.toCharArray())
+                  .build();
 
-      logger.debug("Received response: {}", respEntity);
+            HttpClient httpClient = HttpClients.custom()
+                  .setSSLContext(sslContext)
+                  .build();
 
-      return respEntity;
+            HttpPost httpPost = new HttpPost(uri);
+            httpPost.setHeader("Content-Type", "application/json");
+            org.apache.http.HttpEntity entity2 = new org.apache.http.entity.StringEntity(
+                  new JSONObject(map).toString());
+            httpPost.setEntity(entity2);
+
+            HttpResponse response = httpClient
+                  .execute(httpPost);
+            org.apache.http.HttpEntity apache_entity = response.getEntity();
+            String result = EntityUtils.toString(apache_entity);
+            logger.debug("Returned signature object: {}", result);
+            JSONObject jObj = new JSONObject(result);
+            EntityUtils.consume(apache_entity);
+            return jObj;
+
+         } catch (Exception e) {
+            logger.error("Error creating SSLContext", e);
+            return null;
+         }
+      } else {
+
+         ResponseEntity<String> respEntity = template.postForEntity(uri, entity, String.class);
+         logger.debug("Received response: {}", respEntity);
+
+         return new JSONObject(respEntity.getBody());
+      }
+   }
+
+   private KeyStore readStore() throws Exception {
+      try (InputStream keyStoreStream = this.getClass().getResourceAsStream(keyStorePath)) {
+         KeyStore keyStore = KeyStore.getInstance("JKS");
+         keyStore.load(keyStoreStream, keyStorePassword.toCharArray());
+         return keyStore;
+      } catch (Exception e) {
+         throw new Exception("Error reading keystore", e);
+      }
    }
 
    private ResponseEntity<Map<String, String>> signWithHsm(Message message) {
       return ResponseEntity.status(HttpStatus.OK).body(
-         Collections.singletonMap("result", message + "NOT IMPLEMENTED"));
+            Collections.singletonMap("result", message + "NOT IMPLEMENTED"));
    }
 
    @Override
@@ -217,4 +261,27 @@ public class SignatureController implements EnvironmentAware {
       this.useHsm = useHsm;
    }
 
+   public boolean isUseCertficates() {
+      return useCertficates;
+   }
+
+   public void setUseCertficates(boolean useCertficates) {
+      this.useCertficates = useCertficates;
+   }
+
+   public String getKeyStorePath() {
+      return keyStorePath;
+   }
+
+   public void setKeyStorePath(String keyStorePath) {
+      this.keyStorePath = keyStorePath;
+   }
+
+   public String getKeyStorePassword() {
+      return keyStorePassword;
+   }
+
+   public void setKeyStorePassword(String keyStorePassword) {
+      this.keyStorePassword = keyStorePassword;
+   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,14 @@
 server.port=8090
-#If true, will use internal HSM signing routine. If false, will use external service. MUST be false at this time until the internal functions are implemented.
+# If true, will use internal HSM signing routine. If false, will use external service. MUST be false at this time until the internal functions are implemented.
 sec.useHsm=false
-#The following properties are valid only if sec.useHsm=false
-#Cryptographic service endpoint URI excluding path. For example, `http://<ip>:<por>` OR `http://server.dns.name` including the port number, if any
+# The following properties are valid only if sec.useHsm=false
+# Cryptographic service endpoint URI excluding path. For example, `http://<ip>:<por>` OR `http://server.dns.name` including the port number, if any
 sec.cryptoServiceBaseUri=
-#The REST endpoint path of the xternal service if `sec.useHsm=false`
+# The REST endpoint path of the xternal service if `sec.useHsm=false`
 sec.cryptoServiceEndpointSignPath=/tmc/signtim
 
-#The following properties are valid when sec.useHsm=true
+# Set to true to enable the use of off-site signatory endpoints with MTLS enabled
+sec.useCertficates=true
+# The following properties are valid only if sec.useCertficates=true
+sec.keyStorePath=/home/cert.jks
+sec.keyStorePassword=password


### PR DESCRIPTION
Current functionality of the `jpo-security-svcs` module assumes an on-prem deployment of an HSM for signing messages. Newer signatories are being run in the cloud and require MTLS authentication. This PR adds remote signing capabilities, includes MTLS authentication, and new docker-compose.yml file to show usage. The module remains backwards compatible with on-prem hosted signing.