### PR TITLE
Updating Base Image & Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **.jks
 **.pem
 .env
+**.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,16 @@ COPY ./src ./src
 
 RUN mvn clean package
 
-FROM openjdk:8u171-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
+
+RUN apk update
+RUN apk add ca-certificates
+
+RUN apk add java-cacerts
+RUN rm $JAVA_HOME/lib/security/cacerts
+RUN ln -sf /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
+
+RUN apk add openssl
 
 COPY --from=builder /home/src/main/resources/logback.xml /home
 COPY --from=builder /home/target/jpo-security-svcs.jar /home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,13 @@ services:
       SEC_CRYPTO_SERVICE_BASE_URI: ${SEC_CRYPTO_SERVICE_BASE_URI}
       SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH: ${SEC_CRYPTO_SERVICE_ENDPOINT_SIGN_PATH}
       SEC_USE_CERTFICATES: ${SEC_USE_CERTFICATES}
-      SEC_KEY_STORE_PATH: ${SEC_KEY_STORE_PATH}
+      #SEC_KEY_STORE_PATH: ${SEC_KEY_STORE_PATH}
       SEC_KEY_STORE_PASSWORD: ${SEC_KEY_STORE_PASSWORD}
     volumes: 
-      - ./src/main/resources/creds:/home/creds
-    command: sh -c "cp -a /home/creds/caCerts/. /usr/local/share/ca-certificates/ && update-ca-certificates && java -Dlogback.configurationFile=/home/logback.xml -jar /home/jpo-security-svcs.jar"
+      - ./src/main/resources/creds:/usr/local/share/ca-certificates
+      - ./src/main/resources/cert.jks:/home/cert.jks
+      - ./src/main/resources/logback.xml:/home/logback.xml
+    command: sh -c "update-ca-certificates && java -Dlogback.configurationFile=/home/logback.xml -jar /home/jpo-security-svcs.jar"
     logging:
       options:
         max-size: "10m"  

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>usdot.jpo.ode</groupId>
 	<artifactId>jpo-security-svcs</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 
 	<packaging>jar</packaging>
 	<name>jpo-security-svcs</name>


### PR DESCRIPTION
**Changes**
- The base image has been changed to eclipse-temurin:11-jre-alpine instead of the deprecated openjdk8u171-jre-alpine image.
- The version in the pom.xml has been changed to 1.1.0
- Certificate handling has been modified in the Dockerfile & docker-compose.yml files.